### PR TITLE
fixed ver 1.10.0

### DIFF
--- a/nephio/core/nephio-operator/app/controller/clusterrole-bootstrap.yaml
+++ b/nephio/core/nephio-operator/app/controller/clusterrole-bootstrap.yaml
@@ -23,6 +23,14 @@ rules:
 - apiGroups:
   - '*'
   resources:
+  - configmaps
+  verbs:
+  - update
+  - list
+  - watch
+- apiGroups:
+  - '*'
+  resources:
   - secrets
   verbs:
   - get

--- a/nephio/optional/spire/serconfig.yaml
+++ b/nephio/optional/spire/serconfig.yaml
@@ -44,23 +44,7 @@ data:
         plugin_data {
           clusters = {
             # TODO: Change this to your cluster name
-            "kind" = {
-               use_token_review_api_validation = true
-               service_account_allow_list = ["spire:spire-agent"]
-               service_account_allow_list = ["spire:spire-oidc"]
-             }
-            "regional" = {
-               service_account_allow_list = ["spire:spire-agent"]
-               kube_config_file = "/run/spire/kubeconfigs/regional"
-             }
-            "edge01" = {
-               service_account_allow_list = ["spire:spire-agent"]
-               kube_config_file = "/run/spire/kubeconfigs/edge01"
-             }
-            "edge02" = {
-               service_account_allow_list = ["spire:spire-agent"]
-               kube_config_file = "/run/spire/kubeconfigs/edge02"
-             }
+            plugin_data_file= "/run/spire/clusters/clusters.conf"
            }
          }
        }

--- a/nephio/optional/spire/server-statefulset.yaml
+++ b/nephio/optional/spire/server-statefulset.yaml
@@ -73,6 +73,7 @@ spec:
       containers:
         - name: spire-server
           image: ghcr.io/spiffe/spire-server:1.10.0
+          imagePullPolicy: Never
           args:
             - -config
             - /run/spire/config/server.conf
@@ -117,7 +118,7 @@ spec:
           stdin: true
           tty: true
         - name: spire-oidc
-          image: ghcr.io/spiffe/oidc-discovery-provider:1.5.5
+          image: ghcr.io/spiffe/oidc-discovery-provider:1.10.0
           args:
           - -config
           - /run/spire/oidc/config/oidc-discovery-provider.conf
@@ -147,9 +148,7 @@ spec:
           configMap:
             name: spire-server
         - name: spire-server-socket
-          hostPath:
-            path: /run/spire/sockets/server
-            type: DirectoryOrCreate
+          emptyDir: {}
         - name: spire-oidc-config
           configMap:
             name: oidc-discovery-provider

--- a/nephio/optional/spire/server-statefulset.yaml
+++ b/nephio/optional/spire/server-statefulset.yaml
@@ -86,14 +86,12 @@ spec:
             - name: spire-data
               mountPath: /run/spire/data
               readOnly: false
-            # - name: spire-secrets
-            #   mountPath: /run/spire/secrets
-            #   readOnly: true
             - name: spire-server-socket
               mountPath: /tmp/spire-server/private
               readOnly: false
-            # - name: kubeconfigs
-            #   mountPath: /run/spire/kubeconfigs
+            - name: kubeconfigs
+              mountPath: /run/spire/clusters
+              readOnly: false
           livenessProbe:
             httpGet:
               path: /live
@@ -155,10 +153,12 @@ spec:
         - name: spire-secrets
           secret:
             secretName: spire-server
-        # - name: kubeconfigs
-        #   secret:
-        #     defaultMode: 0400
-        #     secretName: kubeconfigs
+        - name: clusters
+          configMap:
+            name: clusters
+        - name: kubeconfigs
+          configMap:
+            name: kubeconfigs
   volumeClaimTemplates:
     - metadata:
         name: spire-data


### PR DESCRIPTION
Made the shared volume between oidc and spire-server as an empty directory instead of hostpath. Now 1.10.0 reconfiguration works.